### PR TITLE
:shipit: Deploy only master branch.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,9 @@ deploy:
   password:
     secure: epX63djwCcNjxpwWLCd5KP2rjTQGHKfo4FTY+uIKq1gJCdaZix0Dw6XD2SvWQvFKcN9QkbFw993Plwpb41JlNg==
   remove_files: true
+  artifact: WhereIsMyColleague.zip
+  on:
+    branch: master
 notifications:
 - provider: Slack
   channel: wfhsite


### PR DESCRIPTION
This also provides a named project within the solution to deploy to Azure.
Since adding the MVC project to the solution the deployment has been broken as AppVeyor has no way of telling which project to deploy.
Check out the log for build [1.0.43](https://ci.appveyor.com/project/st3v3nhunt/where-is-my-colleague/build/1.0.43) to see no deployment was attempted.